### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <url>https://github.com/wso2-extensions/identity-outbound-provisioning-google.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-outbound-provisioning-google.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-outbound-provisioning-google.git</connection>
-        <tag>v5.2.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
 
@@ -251,8 +251,8 @@
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
 
-        <carbon.identity.framework.version>5.5.0</carbon.identity.framework.version>
-        <carbon.identity.package.import.version.range>[5.0.0, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
+        <carbon.identity.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.package.import.version.range>
 
         <com.google.client.version>1.34.0</com.google.client.version>
         <com.google.service.api.version>directory_v1-rev28-1.17.0-rc</com.google.service.api.version>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16