### PR TITLE
Avoid updating google outbound provisioned user's name with empty string since it is required

### DIFF
--- a/components/org.wso2.carbon.identity.provisioning.connector.google/src/main/java/org/wso2/carbon/identity/provisioning/connector/google/GoogleProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.google/src/main/java/org/wso2/carbon/identity/provisioning/connector/google/GoogleProvisioningConnector.java
@@ -534,6 +534,12 @@ public class GoogleProvisioningConnector extends AbstractOutboundProvisioningCon
         }
         username.setFamilyName(familyNameValue);
 
+        /* If both given name and family name values are empty, skip updating user by returning null. Currently,
+        we only update the name of the Google outbound provisioned users & firstname & lastname are required values
+        in Google account */
+        if (StringUtils.isBlank(username.getGivenName()) && StringUtils.isBlank(username.getFamilyName())) {
+            return null;
+        }
         updateUser.setName(username);
         updateUser.setPassword(generatePassword());
 


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves: https://github.com/wso2/product-is/issues/19165

- Avoid updating google outbound provisioned user's name with empty string since it is required
- Even when creating user in google side for outbound provisioning we are setting WSO2 IS user's username as firstname and lastname.[1][2]

[1] https://github.com/wso2-extensions/identity-outbound-provisioning-google/blob/478fc516e9739b0bc46f86529a70215a377f9795/components/org.wso2.carbon.identity.provisioning.connector.google/src/main/java/org/wso2/carbon/identity/provisioning/connector/google/GoogleProvisioningConnector.java#L433-L447 
[2] https://github.com/wso2-extensions/identity-outbound-provisioning-google/blob/478fc516e9739b0bc46f86529a70215a377f9795/components/org.wso2.carbon.identity.provisioning.connector.google/src/main/java/org/wso2/carbon/identity/provisioning/connector/google/GoogleProvisioningConnector.java#L449-L463

