### PR TITLE
Bump the jackson core dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
         <io.grpc.context.version>1.43.2</io.grpc.context.version>
 
         <maven.scr.plugin.version>1.7.2</maven.scr.plugin.version>
-        <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
+        <maven.bundle.plugin.version>5.1.2</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
         <com.google.client.version>1.34.0</com.google.client.version>
         <com.google.service.api.version>directory_v1-rev28-1.17.0-rc</com.google.service.api.version>
         <com.google.code.findbugs.version>1.3.9</com.google.code.findbugs.version>
-        <com.fasterxml.jackson.version>2.9.9</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.version>2.13.0</com.fasterxml.jackson.version>
         <io.opencensus.api.version>0.30.0</io.opencensus.api.version>
         <io.opencensus.contrib.http.util.version>0.30.0</io.opencensus.contrib.http.util.version>
         <io.grpc.context.version>1.43.2</io.grpc.context.version>


### PR DESCRIPTION
### Proposed changes in this pull request
- The com.fasterxml.jackson.version has been bumped from 2.9.9 to 2.13.0.
- Bump the maven-bundle-plugin as from jackson core 2.11.0 onwards it has multiple release jars and previous maven build plugin version not supported this.


